### PR TITLE
Give Toastada Container Default Positioning Styles

### DIFF
--- a/demo/index.css
+++ b/demo/index.css
@@ -34,7 +34,6 @@
 
 /* Entire toast container */
 .toast-container {
-    position: fixed;
     z-index: 999999999;
     max-width: 300px;
     /*min-width: 300px;*/

--- a/demo/index.css
+++ b/demo/index.css
@@ -32,13 +32,6 @@
 
 /* Toast stylings */
 
-/* Entire toast container */
-.toast-container {
-    z-index: 999999999;
-    max-width: 300px;
-    /*min-width: 300px;*/
-}
-
 /* Each toast gets this style */
 .toast {
     /*width: 300px;*/

--- a/demo/index.js
+++ b/demo/index.js
@@ -77,6 +77,7 @@
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.className = classes.container;
+            toastContainer.style.position = 'fixed';
         }
 
         var newToast = document.createElement('div');
@@ -94,20 +95,20 @@
                     toastContainer.style.right = '10px';
                     break;
 
-                // case 'top-left':
-                //     toastContainer.style.top = '10px';
-                //     toastContainer.style.left = '10px';
-                //     break;
-                //
-                // case 'bottom-left':
-                //     toastContainer.style.bottom = '10px';
-                //     toastContainer.style.left = '10px';
-                //     break;
-                //
-                // case 'bottom-right':
-                //     toastContainer.style.bottom = '10px';
-                //     toastContainer.style.right = '10px';
-                //     break;
+                case 'top-left':
+                    toastContainer.style.top = '10px';
+                    toastContainer.style.left = '10px';
+                    break;
+
+                case 'bottom-left':
+                    toastContainer.style.bottom = '10px';
+                    toastContainer.style.left = '10px';
+                    break;
+
+                case 'bottom-right':
+                    toastContainer.style.bottom = '10px';
+                    toastContainer.style.right = '10px';
+                    break;
 
                 default:
                     toastContainer.style.top = '10px';

--- a/demo/index.js
+++ b/demo/index.js
@@ -20,6 +20,12 @@
         error: 'toast-error'
     };
 
+    var containerStyles = {
+      'position': 'fixed',
+      'z-index': 9999,
+      'min-width': '200px'
+    }
+
     var toastada = {
 
         setOptions: setOptions,
@@ -77,7 +83,9 @@
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.className = classes.container;
-            toastContainer.style.position = 'fixed';
+            for(var key in containerStyles){
+              toastContainer.style[key] = containerStyles[key];
+            }
         }
 
         var newToast = document.createElement('div');

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@
         error: 'toast-error'
     };
 
+    var containerStyles = {
+      position: 'fixed',
+      z-index: 9999,
+      min-width: '200px'
+    }
+
     var toastada = {
 
         setOptions: setOptions,
@@ -77,7 +83,9 @@
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.className = classes.container;
-            toastContainer.style.position = 'fixed';
+            for(var key in containerStyles){
+              toastContainer.style[key] = containerStyles[key];
+            }
         }
 
         var newToast = document.createElement('div');

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.className = classes.container;
+            toastContainer.style.position = 'fixed';
         }
 
         var newToast = document.createElement('div');
@@ -94,20 +95,20 @@
                     toastContainer.style.right = '10px';
                     break;
 
-                // case 'top-left':
-                //     toastContainer.style.top = '10px';
-                //     toastContainer.style.left = '10px';
-                //     break;
-                //
-                // case 'bottom-left':
-                //     toastContainer.style.bottom = '10px';
-                //     toastContainer.style.left = '10px';
-                //     break;
-                //
-                // case 'bottom-right':
-                //     toastContainer.style.bottom = '10px';
-                //     toastContainer.style.right = '10px';
-                //     break;
+                case 'top-left':
+                    toastContainer.style.top = '10px';
+                    toastContainer.style.left = '10px';
+                    break;
+
+                case 'bottom-left':
+                    toastContainer.style.bottom = '10px';
+                    toastContainer.style.left = '10px';
+                    break;
+
+                case 'bottom-right':
+                    toastContainer.style.bottom = '10px';
+                    toastContainer.style.right = '10px';
+                    break;
 
                 default:
                     toastContainer.style.top = '10px';


### PR DESCRIPTION
Allows the `position` option to be used without needing a stylesheet as well as giving the container styles that are core to the functionality of the plugin.