### PR TITLE
Add IE support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,19 @@
 
     }
 
+    function shimForIe(node) {
+        console.log(node);
+        Object.defineProperty(node, 'remove', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function remove() {
+                if (this.parentNode !== null)
+                    this.parentNode.removeChild(this);
+            }
+        });
+    }
+
     function placeToast(html, toastType) {
 
         var toastContainer = document.querySelector('.' + classes.container);
@@ -77,10 +90,12 @@
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.className = classes.container;
+            shimForIe(toastContainer);
         }
 
         var newToast = document.createElement('div');
         newToast.className = classes.default + ' ' + classes[toastType];
+        shimForIe(newToast);
 
         newToast.innerHTML = html;
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@
     }
 
     function shimForIe(node) {
-        console.log(node);
         Object.defineProperty(node, 'remove', {
             configurable: true,
             enumerable: true,


### PR DESCRIPTION
Added a "shim" for IE because it does not support ChildNode.remove(), so containers were hanging around and obscuring anything underneath them like top-right controls.

https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#Specifications

This uses the suggested Polyfill from MDN.
